### PR TITLE
select_economic_event: increase z-index

### DIFF
--- a/lib/web/components/select_economic_event/select_economic_event_live.sface
+++ b/lib/web/components/select_economic_event/select_economic_event_live.sface
@@ -36,7 +36,7 @@
     </div>
   </div>
     
-  <div x-show="selected_economic_event === 'transfer'" class="fixed inset-0 z-10 overflow-y-auto" aria-labelledby="modal-title" x-ref="dialog" aria-modal="true">
+  <div x-show="selected_economic_event === 'transfer'" class="fixed inset-0 z-30 overflow-y-auto" aria-labelledby="modal-title" x-ref="dialog" aria-modal="true">
     <div class="flex items-end justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
       <div x-show="selected_economic_event === 'transfer'" x-transition:enter="ease-out duration-300" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100" x-transition:leave="ease-in duration-200" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0" x-description="Background overlay, show/hide based on modal state." class="fixed inset-0 transition-opacity bg-gray-500 bg-opacity-75"  aria-hidden="true"></div>
       <!-- This element is to trick the browser into centering the modal contents. -->
@@ -50,7 +50,7 @@
       </div>
     </div>
   </div>
-  <div x-show="selected_economic_event === 'produce'" class="fixed inset-0 z-10 overflow-y-auto" aria-labelledby="modal-title" x-ref="dialog" aria-modal="true">
+  <div x-show="selected_economic_event === 'produce'" class="fixed inset-0 z-30 overflow-y-auto" aria-labelledby="modal-title" x-ref="dialog" aria-modal="true">
     <div class="flex items-end justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
       <div x-show="selected_economic_event === 'produce'" x-transition:enter="ease-out duration-300" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100" x-transition:leave="ease-in duration-200" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0" x-description="Background overlay, show/hide based on modal state." class="fixed inset-0 transition-opacity bg-gray-500 bg-opacity-75"  aria-hidden="true"></div>
       <!-- This element is to trick the browser into centering the modal contents. -->
@@ -64,7 +64,7 @@
       </div>
     </div>
   </div>
-  <div x-show="selected_economic_event === 'consume'" class="fixed inset-0 z-10 overflow-y-auto" aria-labelledby="modal-title" x-ref="dialog" aria-modal="true">
+  <div x-show="selected_economic_event === 'consume'" class="fixed inset-0 z-30 overflow-y-auto" aria-labelledby="modal-title" x-ref="dialog" aria-modal="true">
     <div class="flex items-end justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
       <div x-show="selected_economic_event === 'consume'" x-transition:enter="ease-out duration-300" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100" x-transition:leave="ease-in duration-200" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0" x-description="Background overlay, show/hide based on modal state." class="fixed inset-0 transition-opacity bg-gray-500 bg-opacity-75"  aria-hidden="true"></div>
       <!-- This element is to trick the browser into centering the modal contents. -->
@@ -78,7 +78,7 @@
       </div>
     </div>
   </div>
-  <div x-show="selected_economic_event === 'use'" class="fixed inset-0 z-10 overflow-y-auto" aria-labelledby="modal-title" x-ref="dialog" aria-modal="true">
+  <div x-show="selected_economic_event === 'use'" class="fixed inset-0 z-30 overflow-y-auto" aria-labelledby="modal-title" x-ref="dialog" aria-modal="true">
     <div class="flex items-end justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
       <div x-show="selected_economic_event === 'use'" x-transition:enter="ease-out duration-300" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100" x-transition:leave="ease-in duration-200" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0" x-description="Background overlay, show/hide based on modal state." class="fixed inset-0 transition-opacity bg-gray-500 bg-opacity-75"  aria-hidden="true"></div>
       <!-- This element is to trick the browser into centering the modal contents. -->


### PR DESCRIPTION
select_economic_event's modal seems to overlap with bonfire_ui_social's
page_header.  I am increasing the model's z-index, so they don't overlap any
more.

One better solution would be to keep track of the z-index as CSS variables.  Perhaps in the root element and increase them as necessary.  I generally give each layer a unit of 10, so I can give each “sub-layer” its own z-index.  For example, a “navbar” component gets 20-29 range (for things like drop-downs, position:fixed kebab-menu, etc.); modals get 30-39 range (clickable background shadow, modal itself, etc.); pop-ups, messages and the like gets the range 40-49 etc.